### PR TITLE
Update methods for rails 5

### DIFF
--- a/app/controllers/adminsimple/application_controller.rb
+++ b/app/controllers/adminsimple/application_controller.rb
@@ -5,7 +5,7 @@ class Adminsimple::ApplicationController < Adminsimple.configuration.parent_cont
 
   layout :layout
 
-  before_filter :authenticate!
+  before_action :authenticate!
 
   helper_method :body_class
 

--- a/app/controllers/adminsimple/devise/registrations_controller.rb
+++ b/app/controllers/adminsimple/devise/registrations_controller.rb
@@ -4,7 +4,7 @@ class Adminsimple::Devise::RegistrationsController < Devise::RegistrationsContro
 
   layout :layout
 
-  before_filter :authenticate!
+  before_action :authenticate!
 
   private
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Adminsimple::Engine.routes.draw do
   get 'settings' => 'adminsimple/settings#index'
 
   # Styleguide route
-  get 'styleguide(/:action)' => 'adminsimple/styleguide#show', as: :styleguide
+  get 'styleguide' => 'adminsimple/styleguide#show', as: :styleguide
 
   # Devise routing
   devise_for Adminsimple.configuration.devise_model.to_s.pluralize.to_sym,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,6 @@ Adminsimple::Engine.routes.draw do
     controllers: {
       sessions: 'adminsimple/devise/sessions',
       passwords: 'adminsimple/devise/passwords',
-      omniauth_callbacks: 'adminsimple/devise/omniauth_callbacks'
     }
   devise_scope Adminsimple.configuration.devise_model do
     resource :registration,


### PR DESCRIPTION
This PR simply updates `before_filter` -> `before_action` and removes the `(:action)` notation from our routes file. This is simply to eliminate the deprecation warnings in our specs. 